### PR TITLE
Issue #3 Issue `fmplayer fails to compile...` for GNU/Linux

### DIFF
--- a/fmdsp/fmdsp-pacc.h
+++ b/fmdsp/fmdsp-pacc.h
@@ -6,8 +6,8 @@
 struct fmdsp_pacc;
 struct pacc_ctx;
 struct pacc_vtable;
-struct fmdriver_work work;
-struct opna opna;
+struct fmdriver_work;
+struct opna;
 struct fmplayer_fft_input_data;
 struct fmdsp_font;
 


### PR DESCRIPTION
Please consider this a fix.
Tested against Lubuntu 20.04 5.4.0-58-generic #64-Ubuntu SMP Wed Dec 9 08:16:25 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux